### PR TITLE
Resize images before upload - configurable

### DIFF
--- a/GoogleImageShell/ConfigForm.Designer.cs
+++ b/GoogleImageShell/ConfigForm.Designer.cs
@@ -36,11 +36,12 @@
             this.allUsersCheckBox = new System.Windows.Forms.CheckBox();
             this.fileTypeListBox = new System.Windows.Forms.CheckedListBox();
             this.fileTypeLabel = new System.Windows.Forms.Label();
+            this.resizeOnUploadCheckbox = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // installButton
             // 
-            this.installButton.Location = new System.Drawing.Point(12, 171);
+            this.installButton.Location = new System.Drawing.Point(12, 195);
             this.installButton.Name = "installButton";
             this.installButton.Size = new System.Drawing.Size(175, 30);
             this.installButton.TabIndex = 0;
@@ -50,7 +51,7 @@
             // 
             // uninstallButton
             // 
-            this.uninstallButton.Location = new System.Drawing.Point(197, 171);
+            this.uninstallButton.Location = new System.Drawing.Point(197, 195);
             this.uninstallButton.Name = "uninstallButton";
             this.uninstallButton.Size = new System.Drawing.Size(175, 30);
             this.uninstallButton.TabIndex = 1;
@@ -90,7 +91,7 @@
             // allUsersCheckBox
             // 
             this.allUsersCheckBox.AutoSize = true;
-            this.allUsersCheckBox.Location = new System.Drawing.Point(15, 61);
+            this.allUsersCheckBox.Location = new System.Drawing.Point(15, 85);
             this.allUsersCheckBox.Name = "allUsersCheckBox";
             this.allUsersCheckBox.Size = new System.Drawing.Size(307, 17);
             this.allUsersCheckBox.TabIndex = 3;
@@ -101,7 +102,7 @@
             // 
             this.fileTypeListBox.CheckOnClick = true;
             this.fileTypeListBox.FormattingEnabled = true;
-            this.fileTypeListBox.Location = new System.Drawing.Point(12, 101);
+            this.fileTypeListBox.Location = new System.Drawing.Point(12, 125);
             this.fileTypeListBox.Name = "fileTypeListBox";
             this.fileTypeListBox.Size = new System.Drawing.Size(360, 64);
             this.fileTypeListBox.TabIndex = 4;
@@ -109,18 +110,31 @@
             // fileTypeLabel
             // 
             this.fileTypeLabel.AutoSize = true;
-            this.fileTypeLabel.Location = new System.Drawing.Point(12, 85);
+            this.fileTypeLabel.Location = new System.Drawing.Point(12, 109);
             this.fileTypeLabel.Name = "fileTypeLabel";
             this.fileTypeLabel.Size = new System.Drawing.Size(168, 13);
             this.fileTypeLabel.TabIndex = 5;
             this.fileTypeLabel.Text = "Install/uninstall for these file types:";
+            // 
+            // resizeOnUploadCheckbox
+            // 
+            this.resizeOnUploadCheckbox.AutoSize = true;
+            this.resizeOnUploadCheckbox.Checked = true;
+            this.resizeOnUploadCheckbox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.resizeOnUploadCheckbox.Location = new System.Drawing.Point(15, 62);
+            this.resizeOnUploadCheckbox.Name = "resizeOnUploadCheckbox";
+            this.resizeOnUploadCheckbox.Size = new System.Drawing.Size(202, 17);
+            this.resizeOnUploadCheckbox.TabIndex = 6;
+            this.resizeOnUploadCheckbox.Text = "Resize before uploading large images";
+            this.resizeOnUploadCheckbox.UseVisualStyleBackColor = true;
             // 
             // ConfigForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(384, 211);
+            this.ClientSize = new System.Drawing.Size(384, 234);
+            this.Controls.Add(this.resizeOnUploadCheckbox);
             this.Controls.Add(this.fileTypeLabel);
             this.Controls.Add(this.fileTypeListBox);
             this.Controls.Add(this.allUsersCheckBox);
@@ -150,5 +164,6 @@
         private System.Windows.Forms.CheckBox allUsersCheckBox;
         private System.Windows.Forms.CheckedListBox fileTypeListBox;
         private System.Windows.Forms.Label fileTypeLabel;
+        private System.Windows.Forms.CheckBox resizeOnUploadCheckbox;
     }
 }

--- a/GoogleImageShell/ConfigForm.cs
+++ b/GoogleImageShell/ConfigForm.cs
@@ -27,8 +27,9 @@ namespace GoogleImageShell
             string menuText = menuTextTextBox.Text;
             bool includeFileName = includeFileNameCheckBox.Checked;
             bool allUsers = allUsersCheckBox.Checked;
+            bool resizeOnUpload = resizeOnUploadCheckbox.Checked;
             ImageFileType[] types = fileTypeListBox.CheckedItems.Cast<ImageFileType>().ToArray();
-            Install(menuText, includeFileName, allUsers, types);
+            Install(menuText, includeFileName, allUsers, resizeOnUpload, types);
         }
 
         private void uninstallButton_Click(object sender, EventArgs e)
@@ -38,11 +39,11 @@ namespace GoogleImageShell
             Uninstall(allUsers, types);
         }
 
-        private static void Install(string menuText, bool includeFileName, bool allUsers, ImageFileType[] types)
+        private static void Install(string menuText, bool includeFileName, bool allUsers, bool resizeOnUpload, ImageFileType[] types)
         {
             try
             {
-                ShortcutMenu.InstallHandler(menuText, includeFileName, allUsers, types);
+                ShortcutMenu.InstallHandler(menuText, includeFileName, allUsers, resizeOnUpload, types);
             }
             catch (Exception ex)
             {

--- a/GoogleImageShell/ShortcutMenu.cs
+++ b/GoogleImageShell/ShortcutMenu.cs
@@ -18,13 +18,17 @@ namespace GoogleImageShell
             {ImageFileType.BMP, new[] {".bmp"}}
         };
 
-        private static string CreateProgramCommand(bool includeFileName)
+        private static string CreateProgramCommand(bool includeFileName, bool resizeOnUpload)
         {
             string exePath = new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath;
             string command = $"\"{exePath}\" search \"%1\"";
             if (includeFileName)
             {
                 command += " -n";
+            }
+            if (resizeOnUpload)
+            {
+                command += " -r";
             }
             return command;
         }
@@ -37,9 +41,9 @@ namespace GoogleImageShell
             return shellKey;
         }
 
-        public static void InstallHandler(string menuText, bool includeFileName, bool allUsers, ImageFileType[] types)
+        public static void InstallHandler(string menuText, bool includeFileName, bool allUsers, bool resizeOnUpload, ImageFileType[] types)
         {
-            string command = CreateProgramCommand(includeFileName);
+            string command = CreateProgramCommand(includeFileName, resizeOnUpload);
             foreach (ImageFileType fileType in types)
             {
                 foreach (string typeExt in FileTypeMap[fileType])

--- a/GoogleImageShell/UploadForm.cs
+++ b/GoogleImageShell/UploadForm.cs
@@ -10,6 +10,8 @@ namespace GoogleImageShell
     {
         private readonly string _imagePath;
         private readonly bool _includeFileName;
+        private readonly bool _resizeOnUpload;
+
         private readonly CancellationTokenSource _cancelTokenSource = new CancellationTokenSource();
 
         public UploadForm(string[] args)
@@ -19,6 +21,7 @@ namespace GoogleImageShell
             {
                 string arg = args[i];
                 if (arg == "-n") _includeFileName = true;
+                else if (arg == "-r") _resizeOnUpload = true;
                 else _imagePath = arg;
             }
         }
@@ -27,7 +30,9 @@ namespace GoogleImageShell
         {
             Log("Uploading image: " + _imagePath);
             Log("Include file name: " + _includeFileName);
-            Task<string> task = GoogleImages.Search(_imagePath, _includeFileName, _cancelTokenSource.Token);
+            Log("Resize on upload: " + _resizeOnUpload);
+
+            Task<string> task = GoogleImages.Search(_imagePath, _includeFileName, _resizeOnUpload, _cancelTokenSource.Token);
             task.ContinueWith(OnUploadComplete, TaskScheduler.FromCurrentSynchronizationContext());
         }
 


### PR DESCRIPTION
I extended the app to resize large image binaries to 800px to reduce network load. Tested in Windows 10.